### PR TITLE
Support nested lists in `shorewall_params` vars

### DIFF
--- a/molecule/default/inventory/group_vars/all.yml
+++ b/molecule/default/inventory/group_vars/all.yml
@@ -4,3 +4,8 @@ shorewall_group_rules:
   - action: HTTPS(ACCEPT)
     source: net
     dest: $FW
+
+shorewall_group_params:
+  NESTED_LIST:
+    - 10.0.0.1
+    - [10.254.254.1, 10.254.254.2]

--- a/molecule/default/inventory/host_vars/instance.yml
+++ b/molecule/default/inventory/host_vars/instance.yml
@@ -12,3 +12,6 @@ shorewall_host_rules:
     source: "net:1.1.1.1"
     dest: $FW
     skip_when: "{{ ansible_hostname != 'instance' }}"
+
+shorewall_host_params:
+  LOCALHOST: 127.0.0.1

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -71,3 +71,21 @@
           - ^DNS(REJECT) net:1.1.1.1 $FW
           - /etc/shorewall/rules
       changed_when: false
+
+    - name: Ensure nested listed in shorewall_group_params is flattened
+      command:
+        argv:
+          - grep
+          - -q
+          - ^NESTED_LIST=10.0.0.1,10.254.254.1,10.254.254.2
+          - /etc/shorewall/params
+      changed_when: false
+
+    - name: Ensure shorewall_params vars are merged
+      command:
+        argv:
+          - grep
+          - -q
+          - ^LOCALHOST=127.0.0.1
+          - /etc/shorewall/params
+      changed_when: false

--- a/templates/etc/shorewall/params.j2
+++ b/templates/etc/shorewall/params.j2
@@ -27,5 +27,5 @@
 ###############################################################################
 {% set params = shorewall_params|d({}) | combine(shorewall_group_params|d({}), shorewall_host_params|d({})) %}
 {% for param, value in params|dictsort %}
-{{ param }}={{ value|join(',')|quote if value is iterable and value is not string else value|quote }}
+{{ param }}={{ value|flatten|join(',')|quote if value is iterable and value is not string else value|quote }}
 {% endfor %}


### PR DESCRIPTION
This allows useful tricks such as:

```
shorewall_params:
  DBSERVERS: >-
    {{
      groups['dbservers'] |
      map('extract', hostvars, ['ansible_default_ipv4', 'address'])
    }}
```